### PR TITLE
Fix partial jobs

### DIFF
--- a/HPO-demonstration/HPO-EDT/WMLA-HPO-Hyperband-Wells-EDT-external.ipynb
+++ b/HPO-demonstration/HPO-EDT/WMLA-HPO-Hyperband-Wells-EDT-external.ipynb
@@ -1054,10 +1054,11 @@
     "        count=0\n",
     "        Experiment = []\n",
     "        while (count < experiments_length):\n",
-    "                appID = json_out['experiments'][count]['appId']\n",
-    "                #print ('appID: %s,' %appID )\n",
-    "                #print ('count: %d' %count)\n",
-    "                Experiment.insert(count, appID)\n",
+    "                if('appId' in json_out['experiments'][count]):\n",
+    "                    appID = json_out['experiments'][count]['appId']\n",
+    "                    #print ('appID: %s,' %appID )\n",
+    "                    #print ('count: %d' %count)\n",
+    "                    Experiment.insert(count, appID)\n",
     "                count+=1\n",
     " \n",
     "        ####\n",
@@ -1145,7 +1146,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As we are getting task sattus for each job, wmla sometime return malformed
structure when job is not yet completely ready ( state as "NOT READY" ). This
is a preventive fix to avoid failure in notebook.